### PR TITLE
Pagamenti: Bancomat e Carta al posto di POS, commissioni stimate nel resoconto

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,10 @@ default 20). Values arrive as strings — `parseInt` before use.
 
 - **Money is integer euro-cents** everywhere. `displayEuroCents` formats for the UI; never
   carry floats.
+- **Payment modes** stored on the order doc: `cash`, `bancomat`, `carta`, `servizio`
+  (plus legacy `POS` in old history docs — keep handling it in reports). Merchant fees
+  (0.6% bancomat, 0.9% carta) are **estimated only in the Resoconto admin view** —
+  never on the payment screen, receipts, or anything customer-facing.
 - **Dates use Italian time (Europe/Rome), not UTC.** Daily portions reset after 16:00
   Rome time and are keyed `YYYY-MM-DD` in Rome time; the report groups by Rome day too.
   When formatting a date for grouping, use

--- a/src/features/order/PrintableOrder.tsx
+++ b/src/features/order/PrintableOrder.tsx
@@ -30,6 +30,10 @@ export function Total({ onBack, onConfirm, given, setGiven, mode, setMode }: { o
   const products = useAppSelector(selectProducts);
   const total = Object.values(products).reduce((total, product) => total + product.euroCents * product.quantity, 0)
 
+  // Electronic payments (bancomat/carta) behave like the old "POS" mode here:
+  // the customer pays the full total, no change. The merchant fees (0.6%/0.9%)
+  // are deliberately NOT shown here — they only appear in the admin resoconto.
+  const isElectronic = mode === "bancomat" || mode === "carta"
   const resto = mode === "cash" ? given - total : 0
 
   return <>
@@ -38,7 +42,8 @@ export function Total({ onBack, onConfirm, given, setGiven, mode, setMode }: { o
 
       <ButtonGroup>
         <ToggleButton id="mode-cash" value="cash" type="radio" variant={mode === "cash" ? "primary" : "outline-primary"} size="lg" checked={mode === "cash"} onChange={(e) => setMode(e.target.value)}>Contanti</ToggleButton>
-        <ToggleButton id="mode-POS" value="POS" type="radio" variant={mode === "POS" ? "primary" : "outline-primary"} size="lg" checked={mode === "POS"} onChange={(e) => setMode(e.target.value)}>POS</ToggleButton>
+        <ToggleButton id="mode-bancomat" value="bancomat" type="radio" variant={mode === "bancomat" ? "primary" : "outline-primary"} size="lg" checked={mode === "bancomat"} onChange={(e) => setMode(e.target.value)}>Bancomat</ToggleButton>
+        <ToggleButton id="mode-carta" value="carta" type="radio" variant={mode === "carta" ? "primary" : "outline-primary"} size="lg" checked={mode === "carta"} onChange={(e) => setMode(e.target.value)}>Carta</ToggleButton>
         <ToggleButton id="mode-servizio" value="servizio" type="radio" variant={mode === "servizio" ? "primary" : "outline-primary"} size="lg" checked={mode === "servizio"} onChange={(e) => setMode(e.target.value)}>Servizio</ToggleButton>
       </ButtonGroup>
 
@@ -85,7 +90,7 @@ export function Total({ onBack, onConfirm, given, setGiven, mode, setMode }: { o
         </Col>
         <Col>
         <h3>Ricevuto dal cliente:</h3>
-        <h2>{mode === "cash" ? displayEuroCents(given) : mode === "POS" ? displayEuroCents(total) : "-"}</h2>
+        <h2>{mode === "cash" ? displayEuroCents(given) : isElectronic ? displayEuroCents(total) : "-"}</h2>
         </Col>
         <Col>
         <h3>Resto:</h3>
@@ -160,7 +165,7 @@ export function CucinaOrder({ count, coperti, tavolo, given, mode }: { count: st
           {(new Date()).toLocaleTimeString()} {"- "}
           {tavolo ? `Tavolo ${tavolo} - ` : ""}
           {displayEuroCents(totalEuroCents)}
-          {mode === "POS" ? ` (POS)` : ""}
+          {mode === "bancomat" ? ` (BANCOMAT)` : mode === "carta" ? ` (CARTA)` : mode === "POS" ? ` (POS)` : ""}
         </h2>
       </div>
     </div>

--- a/src/features/resoconto/Resoconto.tsx
+++ b/src/features/resoconto/Resoconto.tsx
@@ -39,7 +39,7 @@ interface AggregatedReport {
 interface AggregatedDay {
   products: AggregatedReport;
   totalsEuroCents: number;
-  totalsByMode: Record<string, number>; // cash, POS, servizio
+  totalsByMode: Record<string, number>; // cash, bancomat, carta, servizio (+ legacy POS)
 }
 
 interface ResocontoProps {
@@ -73,8 +73,19 @@ function getTodayISO(): string {
 }
 
 function emptyAgg(): AggregatedDay {
-  return { products: {}, totalsEuroCents: 0, totalsByMode: { cash: 0, POS: 0, servizio: 0 } };
+  return { products: {}, totalsEuroCents: 0, totalsByMode: { cash: 0, bancomat: 0, carta: 0, POS: 0, servizio: 0 } };
 }
+
+// Merchant fees withheld by the payment provider: 0.6% on bancomat (debit),
+// 0.9% on carta (credit). Estimated HERE ONLY, for the internal report — the
+// customer always pays full price and no fee ever appears in the cash flow UI
+// or on receipts. Legacy "POS" orders predate the bancomat/carta split, so we
+// can't know which rate applies and they are left out of the estimate.
+const FEE_BANCOMAT = 0.006;
+const FEE_CARTA = 0.009;
+const estimatedFeeCents = (totalsByMode: Record<string, number>): number =>
+  Math.round((totalsByMode.bancomat || 0) * FEE_BANCOMAT) +
+  Math.round((totalsByMode.carta || 0) * FEE_CARTA);
 
 // Aggregate a set of raw orders into product totals and per-mode money totals.
 function aggregate(orders: RawOrder[]): AggregatedDay {
@@ -219,6 +230,7 @@ const Resoconto: React.FC<ResocontoProps> = ({ firestore }) => {
   const windowStartMs = refreshedAt - hoursBack * 60 * 60 * 1000;
   const serataAgg = aggregate(orders.filter((o) => o.createdMs >= windowStartMs));
   const serataProducts = Object.entries(serataAgg.products).filter(([, info]) => info.quantity > 0);
+  const serataFee = estimatedFeeCents(serataAgg.totalsByMode);
 
   // ---- "Per giornata" view ----
   const dayAgg = aggregatedByDate[selectedDate];
@@ -242,6 +254,9 @@ const Resoconto: React.FC<ResocontoProps> = ({ firestore }) => {
     }
     return progressive;
   })();
+
+  const dayFee = dayAgg ? estimatedFeeCents(dayAgg.totalsByMode) : 0;
+  const progFee = progressiveAgg ? estimatedFeeCents(progressiveAgg.totalsByMode) : 0;
 
   return (
     <div className="container my-4">
@@ -299,15 +314,31 @@ const Resoconto: React.FC<ResocontoProps> = ({ firestore }) => {
                 </tbody>
               </Table>
 
-              <Table bordered className="mt-4" style={{ maxWidth: 400, margin: '0 auto' }}>
+              <Table bordered className="mt-4" style={{ maxWidth: 460, margin: '0 auto' }}>
                 <tbody>
                   <tr className="table-primary fw-bold">
-                    <td>TOTALE PERIODO</td>
+                    <td>{serataFee > 0 ? 'TOTALE PERIODO (lordo)' : 'TOTALE PERIODO'}</td>
                     <td className="text-end">{displayEuro(serataAgg.totalsEuroCents)}</td>
                   </tr>
                   <tr><td className="ps-4">di cui contanti</td><td className="text-end">{displayEuro(serataAgg.totalsByMode.cash || 0)}</td></tr>
-                  <tr><td className="ps-4">di cui POS</td><td className="text-end">{displayEuro(serataAgg.totalsByMode.POS || 0)}</td></tr>
+                  <tr><td className="ps-4">di cui bancomat</td><td className="text-end">{displayEuro(serataAgg.totalsByMode.bancomat || 0)}</td></tr>
+                  <tr><td className="ps-4">di cui carta</td><td className="text-end">{displayEuro(serataAgg.totalsByMode.carta || 0)}</td></tr>
+                  {(serataAgg.totalsByMode.POS || 0) > 0 && (
+                    <tr><td className="ps-4">di cui POS (storico)</td><td className="text-end">{displayEuro(serataAgg.totalsByMode.POS || 0)}</td></tr>
+                  )}
                   <tr><td className="ps-4">di cui gratuiti</td><td className="text-end">{displayEuro(serataAgg.totalsByMode.servizio || 0)}</td></tr>
+                  {serataFee > 0 && (
+                    <>
+                      <tr className="text-muted">
+                        <td className="ps-4">commissioni stimate (0,6% bancomat, 0,9% carta)</td>
+                        <td className="text-end">{displayEuro(-serataFee)}</td>
+                      </tr>
+                      <tr className="table-success fw-bold">
+                        <td>TOTALE NETTO STIMATO</td>
+                        <td className="text-end">{displayEuro(serataAgg.totalsEuroCents - serataFee)}</td>
+                      </tr>
+                    </>
+                  )}
                 </tbody>
               </Table>
             </>
@@ -351,10 +382,10 @@ const Resoconto: React.FC<ResocontoProps> = ({ firestore }) => {
                 </tbody>
               </Table>
 
-              <Table bordered className="mt-4" style={{ maxWidth: 400, margin: '0 auto' }}>
+              <Table bordered className="mt-4" style={{ maxWidth: 460, margin: '0 auto' }}>
                 <tbody>
                   <tr className="table-primary fw-bold">
-                    <td>SUBTOTALE GIORNATA</td>
+                    <td>{progFee > 0 ? 'SUBTOTALE GIORNATA (lordo)' : 'SUBTOTALE GIORNATA'}</td>
                     <td>{displayEuro(dayAgg.totalsEuroCents)}</td>
                     <td>{displayEuro(progressiveAgg.totalsEuroCents)}</td>
                   </tr>
@@ -364,15 +395,41 @@ const Resoconto: React.FC<ResocontoProps> = ({ firestore }) => {
                     <td>{displayEuro(progressiveAgg.totalsByMode.cash || 0)}</td>
                   </tr>
                   <tr>
-                    <td className="ps-4">di cui POS</td>
-                    <td>{displayEuro(dayAgg.totalsByMode.POS || 0)}</td>
-                    <td>{displayEuro(progressiveAgg.totalsByMode.POS || 0)}</td>
+                    <td className="ps-4">di cui bancomat</td>
+                    <td>{displayEuro(dayAgg.totalsByMode.bancomat || 0)}</td>
+                    <td>{displayEuro(progressiveAgg.totalsByMode.bancomat || 0)}</td>
                   </tr>
+                  <tr>
+                    <td className="ps-4">di cui carta</td>
+                    <td>{displayEuro(dayAgg.totalsByMode.carta || 0)}</td>
+                    <td>{displayEuro(progressiveAgg.totalsByMode.carta || 0)}</td>
+                  </tr>
+                  {(progressiveAgg.totalsByMode.POS || 0) > 0 && (
+                    <tr>
+                      <td className="ps-4">di cui POS (storico)</td>
+                      <td>{displayEuro(dayAgg.totalsByMode.POS || 0)}</td>
+                      <td>{displayEuro(progressiveAgg.totalsByMode.POS || 0)}</td>
+                    </tr>
+                  )}
                   <tr>
                     <td className="ps-4">di cui gratuiti</td>
                     <td>{displayEuro(dayAgg.totalsByMode.servizio || 0)}</td>
                     <td>{displayEuro(progressiveAgg.totalsByMode.servizio || 0)}</td>
                   </tr>
+                  {progFee > 0 && (
+                    <>
+                      <tr className="text-muted">
+                        <td className="ps-4">commissioni stimate (0,6% bancomat, 0,9% carta)</td>
+                        <td>{displayEuro(-dayFee)}</td>
+                        <td>{displayEuro(-progFee)}</td>
+                      </tr>
+                      <tr className="table-success fw-bold">
+                        <td>TOTALE NETTO STIMATO</td>
+                        <td>{displayEuro(dayAgg.totalsEuroCents - dayFee)}</td>
+                        <td>{displayEuro(progressiveAgg.totalsEuroCents - progFee)}</td>
+                      </tr>
+                    </>
+                  )}
                 </tbody>
               </Table>
             </>


### PR DESCRIPTION
## Cosa

1. **Schermata pagamento**: il bottone unico "POS" è sostituito da due opzioni, **Bancomat** e **Carta**. Entrambe si comportano come il vecchio POS: il cliente paga il totale pieno, nessun resto. Lo scontrino cucina marca `(BANCOMAT)` / `(CARTA)` come prima marcava `(POS)`.
2. **Resoconto (solo admin)**: le righe per modalità ora distinguono bancomat e carta, e quando ci sono pagamenti elettronici compaiono due righe in più:
   - **commissioni stimate** (−0,6% sul bancomat, −0,9% sulla carta);
   - **TOTALE NETTO STIMATO** = totale lordo − commissioni.

## Dove NON compaiono le commissioni (per scelta)

Solo ed esclusivamente nel resoconto interno. Mai:
- nella schermata di pagamento (il cliente paga il prezzo pieno);
- sugli scontrini;
- nei totali di cassa.

Le righe lorde del resoconto restano invariate, così continuano a quadrare con il cassetto contanti e con gli scontrini del terminale POS; il netto stimato è una riga aggiuntiva evidenziata.

## Compatibilità con lo storico

- I vecchi ordini salvati con `mode: "POS"` restano visibili nel resoconto in una riga **"di cui POS (storico)"**, mostrata solo se ce ne sono.
- Per quegli ordini non si può sapere se erano bancomat o carta, quindi sono **esclusi dalla stima delle commissioni** (meglio non stimare che stimare male).
- Le commissioni sono calcolate sui totali aggregati e arrotondate al centesimo; tutta la matematica resta in centesimi interi.

## Verifica

`tsc --noEmit`, test (3/3) e `npm run build` passano.

https://claude.ai/code/session_01M5VuCfJJ8mKNQ7tq7eAfFn

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5VuCfJJ8mKNQ7tq7eAfFn)_