### PR TITLE
Parole magiche più robuste: Caps Lock, tastiere virtuali/IME, focus dopo stampa

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,7 +124,9 @@ default 20). Values arrive as strings — `parseInt` before use.
   by the current "service day" (`currentServiceDayKey`, which rolls over at 17:00
   Europe/Rome), so staff re-enter once per evening. Empty/unset password disables the
   gate (e.g. in tests). The password is in the client bundle — convenience, not security.
-- **Hidden keyboard shortcuts** (type the word anywhere, handled by `useDetectKeypress`):
+- **Hidden keyboard shortcuts** (type the word anywhere, handled by `useDetectKeypress`;
+  matching is case-insensitive and also listens to `beforeinput` so Caps Lock,
+  auto-capitalization, and on-screen/IME keyboards work):
   - `alpaca` → clear the offline counter prefix (re-show A/B/C picker)
   - `pizza` → open the portions admin modal
   - `resoconto` → open the end-of-day report view

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -151,7 +151,11 @@ function App({ firestore }: { firestore: any }) {
 
   const componentRef = useRef(null);
   const handlePrint = useReactToPrint({
-    content: () => componentRef.current
+    content: () => componentRef.current,
+    // Some browsers leave keyboard focus on react-to-print's hidden iframe
+    // after the print dialog closes; keydown then never reaches this document
+    // and the typed-word shortcuts stop working until reload.
+    onAfterPrint: () => window.focus()
   });
 
   const handleConfirm = async () => {

--- a/src/useDetectKeypress.test.tsx
+++ b/src/useDetectKeypress.test.tsx
@@ -1,0 +1,103 @@
+import { renderHook, fireEvent } from '@testing-library/react';
+import useDetectKeypress from './useDetectKeypress';
+
+const typeKeys = (text: string, init: any = {}) => {
+  for (const key of text) {
+    fireEvent.keyDown(document, { key, ...init });
+  }
+};
+
+const fireBeforeInput = (data: string, inputType = 'insertText') => {
+  // jsdom's InputEvent doesn't reliably support inputType, so build a plain
+  // event carrying the same fields the hook reads.
+  const event = new Event('beforeinput', { bubbles: true }) as any;
+  event.inputType = inputType;
+  event.data = data;
+  fireEvent(document, event);
+};
+
+test('detects the word typed on a hardware keyboard', () => {
+  const callback = jest.fn();
+  renderHook(() => useDetectKeypress('pizza', callback));
+
+  typeKeys('pizza');
+  expect(callback).toHaveBeenCalledTimes(1);
+});
+
+test('detects the word regardless of case (Caps Lock, auto-capitalization)', () => {
+  const callback = jest.fn();
+  renderHook(() => useDetectKeypress('pizza', callback));
+
+  typeKeys('PIZZA');
+  expect(callback).toHaveBeenCalledTimes(1);
+});
+
+test('detects capitals typed with Shift held', () => {
+  const callback = jest.fn();
+  renderHook(() => useDetectKeypress('pizza', callback));
+
+  typeKeys('Pizza'.charAt(0), { shiftKey: true });
+  typeKeys('izza');
+  expect(callback).toHaveBeenCalledTimes(1);
+});
+
+test('ignores keys pressed with ctrl, alt or meta modifiers', () => {
+  const callback = jest.fn();
+  renderHook(() => useDetectKeypress('pizza', callback));
+
+  typeKeys('pizza', { ctrlKey: true });
+  typeKeys('pizza', { altKey: true });
+  typeKeys('pizza', { metaKey: true });
+  expect(callback).not.toHaveBeenCalled();
+});
+
+test('does not fire on unrelated text', () => {
+  const callback = jest.fn();
+  renderHook(() => useDetectKeypress('pizza', callback));
+
+  typeKeys('pasta al forno');
+  expect(callback).not.toHaveBeenCalled();
+});
+
+test('fires again after a match (buffers reset)', () => {
+  const callback = jest.fn();
+  renderHook(() => useDetectKeypress('pizza', callback));
+
+  typeKeys('pizza');
+  typeKeys('pizza');
+  expect(callback).toHaveBeenCalledTimes(2);
+});
+
+test('detects virtual keyboards that only emit beforeinput (keydown "Unidentified")', () => {
+  const callback = jest.fn();
+  renderHook(() => useDetectKeypress('pizza', callback));
+
+  for (const char of 'pizza') {
+    fireEvent.keyDown(document, { key: 'Unidentified' });
+    fireBeforeInput(char);
+  }
+  expect(callback).toHaveBeenCalledTimes(1);
+});
+
+test('detects IME composition (insertCompositionText with cumulative data)', () => {
+  const callback = jest.fn();
+  renderHook(() => useDetectKeypress('pizza', callback));
+
+  for (const partial of ['p', 'pi', 'piz', 'pizz', 'pizza']) {
+    fireEvent.keyDown(document, { key: 'Unidentified' });
+    fireBeforeInput(partial, 'insertCompositionText');
+  }
+  expect(callback).toHaveBeenCalledTimes(1);
+});
+
+test('fires once when keydown and beforeinput both report the same keystroke', () => {
+  const callback = jest.fn();
+  renderHook(() => useDetectKeypress('pizza', callback));
+
+  // Typing inside a focused text input produces both events per keystroke.
+  for (const char of 'pizza') {
+    fireEvent.keyDown(document, { key: char });
+    fireBeforeInput(char);
+  }
+  expect(callback).toHaveBeenCalledTimes(1);
+});

--- a/src/useDetectKeypress.ts
+++ b/src/useDetectKeypress.ts
@@ -1,37 +1,60 @@
 import { useState, useEffect, useCallback } from 'react';
 
-const useDetectKeypress = (string: string, callback: () => void) => {
-  const [something, setSomething] = useState("")
+// Detect a "magic word" typed anywhere in the app (e.g. "pizza", "resoconto").
+//
+// Two independent buffers feed the match:
+// - keydown events: physical keyboards, work even with no input focused;
+// - beforeinput events: on-screen/virtual keyboards and IME composition,
+//   where keydown often reports "Unidentified" and carries no character.
+// Matching is case-insensitive so Caps Lock, Shift or a tablet's
+// auto-capitalization can't silently break the shortcuts.
+const useDetectKeypress = (word: string, callback: () => void) => {
+  const [keyBuffer, setKeyBuffer] = useState("")
+  const [inputBuffer, setInputBuffer] = useState("")
 
   // Fire the callback in an effect rather than during render: invoking a
   // parent's setState while this hook renders triggers React's "Cannot update a
   // component while rendering a different component" error and makes the
   // shortcuts unreliable.
   useEffect(() => {
-    if (something === string) {
+    const target = word.toLowerCase()
+    if (keyBuffer === target || inputBuffer.endsWith(target)) {
       callback()
-      setSomething("")
+      setKeyBuffer("")
+      setInputBuffer("")
     }
-  }, [something, string, callback])
+  }, [keyBuffer, inputBuffer, word, callback])
 
   const onKeyDown = useCallback((event: any) => {
     if (!event.key) return
     if (event.altKey) return
     if (event.ctrlKey) return
     if (event.metaKey) return
-    if (event.shiftKey) return
     if (event.key.length !== 1) return
 
-    setSomething(something => (something + event.key).slice(-string.length))
-  }, [setSomething, string.length])
+    setKeyBuffer(buffer => (buffer + event.key.toLowerCase()).slice(-word.length))
+  }, [word.length])
+
+  const onBeforeInput = useCallback((event: any) => {
+    // insertCompositionText carries the whole composition so far on each
+    // keystroke; appending and keeping the tail still ends with the full word.
+    if (event.inputType !== "insertText" && event.inputType !== "insertCompositionText") return
+    if (!event.data) return
+
+    setInputBuffer(buffer => (buffer + event.data.toLowerCase()).slice(-word.length))
+  }, [word.length])
 
   useEffect(() => {
-    document.addEventListener("keydown", onKeyDown, false)
+    // Capture phase: a component calling stopPropagation on keydown must not
+    // be able to disable the shortcuts.
+    document.addEventListener("keydown", onKeyDown, true)
+    document.addEventListener("beforeinput", onBeforeInput, true)
 
     return () => {
-      document.removeEventListener("keydown", onKeyDown, false)
+      document.removeEventListener("keydown", onKeyDown, true)
+      document.removeEventListener("beforeinput", onBeforeInput, true)
     }
-  }, [onKeyDown])
+  }, [onKeyDown, onBeforeInput])
 }
 
 export default useDetectKeypress;


### PR DESCRIPTION
## Problema

Segnalazione dal campo (Lucia, sagra in corso): ogni tanto le parole magiche (`pizza`, `resoconto`, `alpaca`) non vengono riconosciute e bisogna chiudere e riaprire l'app a tutto schermo.

## Cause individuate in `useDetectKeypress`

1. **Confronto case-sensitive + scarto dei tasti con Shift.** Con il Caps Lock attivo (o l'auto-maiuscola della tastiera del tablet) i caratteri arrivano maiuscoli: `PIZZA ≠ pizza`, quindi la parola non viene mai riconosciuta — e il problema persiste finché lo stato della tastiera non cambia, il che spiega perché sembri "risolversi" riavviando.
2. **Solo `keydown`.** Le tastiere a schermo / IME (es. Gboard su Android) spesso emettono `keydown` con `key: "Unidentified"`, che veniva scartato: nessun carattere entrava mai nel buffer.
3. **Focus perso dopo la stampa.** Alcuni browser lasciano il focus sull'iframe nascosto di react-to-print dopo la chiusura del dialogo di stampa: i `keydown` non raggiungono più il documento fino al reload.

## Modifiche

- Match **case-insensitive** e niente più scarto dei tasti con Shift (restano esclusi Ctrl/Alt/Meta).
- Secondo buffer alimentato dagli eventi **`beforeinput`** (`insertText` e `insertCompositionText`), così le tastiere virtuali e la composizione IME funzionano; i due buffer sono indipendenti, quindi una tastiera normale che genera entrambi gli eventi non fa doppio trigger (test dedicato).
- Listener in **capture phase**: un eventuale `stopPropagation` a valle non può disattivare le scorciatoie.
- `onAfterPrint: () => window.focus()` in `App.tsx` per riprendere il focus dopo la stampa.
- 9 test nuovi per l'hook (`src/useDetectKeypress.test.tsx`) + nota aggiornata in `CLAUDE.md`.

Nota: il match case-insensitive rende leggermente più facile un trigger accidentale digitando "Pizza" nel campo note — ma il trigger con "pizza" minuscolo esisteva già, e il modale admin si chiude senza conseguenze.

## Verifiche

- `tsc --noEmit` ✅
- `CI=true npx react-scripts test --watchAll=false`: 20/20 ✅
- `npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TcG7wsErK2A5CZ5pTXD6xR

---
_Generated by [Claude Code](https://claude.ai/code/session_01TcG7wsErK2A5CZ5pTXD6xR)_