### PR TITLE
Numeri d'ordine duplicati: contatore atomico con transazione + conteggio ordini nel Resoconto

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,9 @@ only the API key comes from env.
   daily-portion tracking (thunks: `getMenu`, `getDailyPortions`,
   `forceReloadDailyPortions`, `resetSinglePortion`, `decrementPortion`).
 - **`src/features/counter/counterSlice.ts`** — sequential order number. Online: 4-digit
-  Firestore counter. Offline fallback: 3-digit localStorage counter with an A/B/C prefix.
+  Firestore counter, incremented inside `runTransaction` — never a plain
+  getDoc/updateDoc pair, which let two tills print the same number.
+  Offline fallback: 3-digit localStorage counter with an A/B/C prefix.
 - **`src/features/order/PrintableOrder.tsx`** — the `Total` payment screen, the on-screen
   `RecapOrder`, and the print-only `PrintableOrder` (renders the kitchen receipt twice
   with a page break). Receipt font sizes scale with item count.

--- a/src/features/counter/counterSlice.spec.ts
+++ b/src/features/counter/counterSlice.spec.ts
@@ -1,8 +1,14 @@
 import counterReducer, {
   CounterState,
-  // increment,
+  increment,
   reset
 } from './counterSlice';
+import { doc, runTransaction } from '@firebase/firestore/lite';
+
+jest.mock('@firebase/firestore/lite', () => ({
+  doc: jest.fn(),
+  runTransaction: jest.fn(),
+}));
 
 describe('counter reducer', () => {
   const initialState: CounterState = {
@@ -16,13 +22,41 @@ describe('counter reducer', () => {
     });
   });
 
-  // it('should handle increment', () => {
-  //   const actual = counterReducer(initialState, increment());
-  //   expect(actual.value).toEqual(4);
-  // });
-
   it('should handle reset', () => {
     const actual = counterReducer(initialState, reset());
     expect(actual.value).toEqual(undefined);
+  });
+});
+
+describe('increment thunk', () => {
+  beforeEach(() => {
+    // CRA's jest config has resetMocks: true, so re-arm implementations here.
+    (doc as jest.Mock).mockReturnValue('sagra-doc-ref');
+    window.localStorage.clear();
+  });
+
+  it('reads and writes the counter inside a single transaction (no duplicate numbers across tills)', async () => {
+    const update = jest.fn();
+    (runTransaction as jest.Mock).mockImplementation(async (_firestore, txFn) =>
+      txFn({
+        get: async () => ({ get: (field: string) => (field === 'count' ? 4481 : undefined) }),
+        update,
+      })
+    );
+
+    const action = await (increment('fake-firestore') as any)(jest.fn(), jest.fn(), undefined);
+
+    expect(action.payload).toEqual({ value: 4481, isOnline: true });
+    expect(update).toHaveBeenCalledWith('sagra-doc-ref', { count: 4482 });
+  });
+
+  it('falls back to the localStorage counter when Firestore is unreachable', async () => {
+    (runTransaction as jest.Mock).mockRejectedValue(new Error('offline'));
+    window.localStorage.setItem('count', '123');
+
+    const action = await (increment('fake-firestore') as any)(jest.fn(), jest.fn(), undefined);
+
+    expect(action.payload).toEqual({ value: 123, isOnline: false });
+    expect(window.localStorage.getItem('count')).toBe('124');
   });
 });

--- a/src/features/counter/counterSlice.ts
+++ b/src/features/counter/counterSlice.ts
@@ -2,9 +2,8 @@ import { useState } from 'react'
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 import { RootState } from '../../app/store';
 import {
-  getDoc,
-  updateDoc,
-  doc
+  doc,
+  runTransaction
 } from '@firebase/firestore/lite';
 
 const incrementWithLocalStorage = async () => {
@@ -26,16 +25,21 @@ const incrementWithLocalStorage = async () => {
 }
 
 const incrementWithFirestore = async (firestore: any) => {
-  // TODO: try to use firestore not lite to do it atomically and protect from race conditions
+  // Read + increment inside a transaction. The previous getDoc/updateDoc pair
+  // was not atomic: two tills confirming in the same moment both read N and
+  // both printed order number N (it happened for real). The transaction
+  // retries on contention, so each till gets its own number.
   const docRef = doc(firestore, `sagre/${process.env.REACT_APP_SAGRA_ID}`);
-  const count = (await getDoc(docRef)).get("count");
-  if (count) {
+  const value = await runTransaction(firestore, async (transaction: any) => {
+    const count = (await transaction.get(docRef)).get("count");
+    if (!count) {
+      throw new Error("Couldn't increment with firestore");
+    }
     console.log(count)
-    await updateDoc(docRef, "count", count + 1);
-    return { value: count, isOnline: true }
-  } else {
-    throw new Error("Couldn't increment with firestore");
-  }
+    transaction.update(docRef, { count: count + 1 });
+    return count;
+  });
+  return { value, isOnline: true }
 }
 
 export interface CounterState {

--- a/src/features/resoconto/Resoconto.tsx
+++ b/src/features/resoconto/Resoconto.tsx
@@ -38,6 +38,7 @@ interface AggregatedReport {
 
 interface AggregatedDay {
   products: AggregatedReport;
+  orderCount: number;
   totalsEuroCents: number;
   totalsByMode: Record<string, number>; // cash, bancomat, carta, servizio (+ legacy POS)
 }
@@ -95,7 +96,7 @@ export function latestResetMsFor(dateISO: string, resets: number[]): number {
 }
 
 function emptyAgg(): AggregatedDay {
-  return { products: {}, totalsEuroCents: 0, totalsByMode: { cash: 0, bancomat: 0, carta: 0, POS: 0, servizio: 0 } };
+  return { products: {}, orderCount: 0, totalsEuroCents: 0, totalsByMode: { cash: 0, bancomat: 0, carta: 0, POS: 0, servizio: 0 } };
 }
 
 // Merchant fees withheld by the payment provider: 0.6% on bancomat (debit),
@@ -122,6 +123,7 @@ export function aggregate(orders: RawOrder[]): AggregatedDay {
         agg.products[product.name].euroCents += product.euroCents * product.quantity;
       }
     }
+    agg.orderCount += 1;
     agg.totalsEuroCents += order.euroCents;
     if (!agg.totalsByMode[order.mode]) agg.totalsByMode[order.mode] = 0;
     agg.totalsByMode[order.mode] += order.euroCents;
@@ -380,6 +382,10 @@ const Resoconto: React.FC<ResocontoProps> = ({ firestore }) => {
 
               <Table bordered className="mt-4" style={{ maxWidth: 460, margin: '0 auto' }}>
                 <tbody>
+                  <tr className="fw-bold">
+                    <td>ORDINI PROCESSATI</td>
+                    <td className="text-end">{serataAgg.orderCount}</td>
+                  </tr>
                   <tr className="table-primary fw-bold">
                     <td>{serataFee > 0 ? 'TOTALE PERIODO (lordo)' : 'TOTALE PERIODO'}</td>
                     <td className="text-end">{displayEuro(serataAgg.totalsEuroCents)}</td>
@@ -475,6 +481,11 @@ const Resoconto: React.FC<ResocontoProps> = ({ firestore }) => {
 
               <Table bordered className="mt-4" style={{ maxWidth: 460, margin: '0 auto' }}>
                 <tbody>
+                  <tr className="fw-bold">
+                    <td>ORDINI PROCESSATI</td>
+                    <td>{dayAgg.orderCount}</td>
+                    <td>{progressiveAgg.orderCount}</td>
+                  </tr>
                   <tr className="table-primary fw-bold">
                     <td>{progFee > 0 ? 'SUBTOTALE GIORNATA (lordo)' : 'SUBTOTALE GIORNATA'}</td>
                     <td>{displayEuro(dayAgg.totalsEuroCents)}</td>

--- a/src/features/resoconto/resoconto.spec.ts
+++ b/src/features/resoconto/resoconto.spec.ts
@@ -62,6 +62,7 @@ describe('aggregate', () => {
     const agg = aggregate(orders);
     expect(agg.products['Tordelli']).toEqual({ quantity: 3, euroCents: 2400 });
     expect(agg.products['Panigacci']).toEqual({ quantity: 3, euroCents: 1500 });
+    expect(agg.orderCount).toBe(2);
     expect(agg.totalsEuroCents).toBe(3900);
     expect(agg.totalsByMode.cash).toBe(1600);
     expect(agg.totalsByMode.bancomat).toBe(2300);


### PR DESCRIPTION
## Problema 1: due ordini con lo stesso numero (4481)

Le due ricevute nella foto hanno timestamp 21:25:04 e 21:25:05: due casse hanno confermato l'ordine nello stesso momento. `incrementWithFirestore` faceva **read-modify-write non atomico** (`getDoc` → `updateDoc count+1`) — c'era anche il TODO nel codice che lo segnalava. Entrambe le casse leggono 4481, entrambe scrivono 4482, entrambe stampano 4481.

**Fix**: l'incremento ora avviene dentro `runTransaction` (disponibile anche nella SDK `firestore/lite` in uso). In caso di contesa la transazione riprova automaticamente, quindi ogni cassa ottiene un numero diverso. Comportamento invariato per il resto: viene restituito il valore pre-incremento e in caso di errore/offline resta il fallback su localStorage con prefisso A/B/C.

## Problema 2: quantità di ordini nel resoconto

Aggiunta la riga **ORDINI PROCESSATI** in cima alla tabella dei totali:
- vista **Serata (ultime N ore)**: ordini nel periodo;
- vista **Per giornata**: parziale giornata + progressivo, con le stesse regole di azzeramenti/anno degli altri totali.

## Test

- Nuovi test sul thunk `increment` con transazione mockata: valore pre-incremento restituito, scrittura `count+1`, fallback localStorage quando Firestore non è raggiungibile.
- `aggregate` ora verifica anche `orderCount`.
- `tsc --noEmit` ✅ · test one-shot 22/22 ✅ · `npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TcG7wsErK2A5CZ5pTXD6xR

---
_Generated by [Claude Code](https://claude.ai/code/session_01TcG7wsErK2A5CZ5pTXD6xR)_